### PR TITLE
Grab values dynamically and help improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/VTm4Jd1GnYcRgnzPRDD9GzX6/nourharidy/meteor-ssl.svg' />
 </a>
 
-## Install
+## Quickstart
 ```sh
 meteor add nourharidy:ssl 
 ```
@@ -18,6 +18,14 @@ openssl req -new -x509 -key localhost.key -out localhost.cert -days 3650 -subj /
 ```
 _If you want to use a host other than localhost then replace every reference to “localhost” above witb your custom domain_.
 
+```
+// somewhere within your server code
+SSL(
+  Assets.getText("localhost.key"),
+  Assets.getText("localhost.cert"),
+  443);
+```
+
 ## API
 ### SSL(**key**, **cert**, [**port**])
 #### Server Javascript function
@@ -27,7 +35,7 @@ The function has two obligatory arguments: The UTF-8 formatted string of the SSL
 
 Example:
 ```sh
-SSL(Assets.getText("server.key"), Assets.getText("server.cert"), 443);
+SSL("server.key", "server.cert", 443);
 ```
 
 ### isHTTPS()

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@
 ```sh
 meteor add nourharidy:ssl 
 ```
-After the package installation has finished, it is recommended to put your SSL **key** & **cert** files inside your Meteor *private* directory. However, you can put it wherever else you want **outside** the meteor application directory.
+After the package installation has finished, you place your SSL **key** & **cert** files inside your Meteor *private* directory. 
+
+```sh
+openssl genrsa -out localhost.key 2048
+openssl req -new -x509 -key localhost.key -out localhost.cert -days 3650 -subj /CN=localhost
+```
+_If you want to use a host other than localhost then replace every reference to “localhost” above witb your custom domain_.
 
 ## API
 ### SSL(**key**, **cert**, [**port**])
@@ -85,6 +91,11 @@ This is why you are encouraged to use the default SSL port *443* so you can open
 ```sh
 https://localhost
 ```
+To Revert the effects caused by running sudo, run this command:
+```sh
+sudo chown -Rh <username> .meteor/local
+```
+
 * This package does not encrypt communication between Meteor & MongoDB, to workaround this you must put MongoDB on Meteor's localhost or a server inside your secure private network.
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The function has two obligatory arguments: The *absolute path* to the SSL **key*
 
 Example:
 ```sh
-SSL('/home/user/app/private/server.key','/home/user/app/private/server.crt', 443);
+SSL(Assets.getText("server.key"), Assets.getText("server.cert"), 443);
 ```
 
 ### isHTTPS()

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ After the package installation has finished, it is recommended to put your SSL *
 #### Server Javascript function
 The **SSL()** function is used to launch the SSL functionality from the server, the SSL feature wont be present unless you use it, it must only be used inside the *server* directory.
 
-The function has two obligatory arguments: The *absolute path* to the SSL **key** & the SSL **cert** file, respectively. The third argument is optional: Define the SSL **port** (Default: 443).
+The function has two obligatory arguments: The UTF-8 formatted string of the SSL **key** & the SSL **cert** files, respectively. The third argument is optional: Define the SSL **port** (Default: 443).
 
 Example:
 ```sh

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ openssl req -new -x509 -key localhost.key -out localhost.cert -days 3650 -subj /
 ```
 _If you want to use a host other than localhost then replace every reference to “localhost” above witb your custom domain_.
 
-```
+```sh
 // somewhere within your server code
 SSL(
   Assets.getText("localhost.key"),
@@ -35,7 +35,10 @@ The function has two obligatory arguments: The UTF-8 formatted string of the SSL
 
 Example:
 ```sh
-SSL("server.key", "server.cert", 443);
+SSL(
+  Assets.getText("localhost.key"),
+  Assets.getText("localhost.cert"),
+  443);
 ```
 
 ### isHTTPS()

--- a/ssl.js
+++ b/ssl.js
@@ -11,8 +11,8 @@ SSL = function(key, cert, port){
     		port: process.env.PORT
   		},
   		ssl: {
-    		key: fs.readFileSync(key, 'utf8'),
-    		cert: fs.readFileSync(cert, 'utf8')
+    		key,
+    		cert
  		},
  		ws: true,
  		xfwd: true

--- a/ssl.js
+++ b/ssl.js
@@ -5,10 +5,12 @@ SSL = function(key, cert, port){
 		port = 443;
 	};
 	
+	const [,, host, targetPort] = Meteor.absoluteUrl().match(/([a-zA-Z]+):\/\/([\-\w\.]+)(?:\:(\d{0,5}))?/)
+
 	proxy = httpProxy.createServer({
 		target: {
-    		host: 'localhost',
-    		port: process.env.PORT
+    		host,
+    		port: targetPort
   		},
   		ssl: {
     		key,


### PR DESCRIPTION
Replace `readFileSync` with [Assets.getText](https://docs.meteor.com/api/assets.html#Assets-getText) which enforces users to place their files within `private` which is very suitable security-wise with the added benefit of not having to type out the whole path. 

```
SSL(
  Assets.getText("localhost.key"),
  Assets.getText("localhost.cert"),
  443);
```

Both host and port of the targeted app are extracted dynamically from `Meteor.absoluteUrl` leads to more accurate results instead of hard-coding the host.
```
...
	const [,, host, targetPort] = Meteor.absoluteUrl().match(/([a-zA-Z]+):\/\/([\-\w\.]+)(?:\:(\d{0,5}))?/)

	proxy = httpProxy.createServer({
		target: {
    		host,
    		port: targetPort
  		},
...
```

Finally, the doc was modified accordingly to reflect those changes with "install" section being modeled into "quickstart" for getting users up to speed with SSL generating command too.

Thanks for such an awesome packages, cheers!    