### PR TITLE
Quick fix for calling SSL()

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ The function has two obligatory arguments: The UTF-8 formatted string of the SSL
 Example:
 ```sh
 SSL(
-  Assets.getText("localhost.key"),
-  Assets.getText("localhost.cert"),
+  Assets.absoluteFilePath("localhost.key"),
+  Assets.absoluteFilePath("localhost.cert"),
   443);
 ```
 


### PR DESCRIPTION
The SSL function now apparently takes the _path_ to the certificate files... so the example shown here wasn't quite right.